### PR TITLE
minor typos fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 A lightweight face anti-spoofing model that distinguishes real faces from spoofing attempts (printed photos, screen displays, etc.). Used in [**SURI**](https://github.com/johnraivenolazo/suri), an AI attendance system.
 
-This repo contains the training pipeline, pretrained weights, and ONNX export. Standalone repository for training and optimization.
+This repo contains the training pipeline, pre-trained weights, and ONNX export. Standalone repository for training and optimization.
 
 ---
 
@@ -128,7 +128,7 @@ pip install -r requirements.txt
 > **Python Version:** This project requires **Python 3.8.0 or higher**.
 
 ### Compatibility Note: Python 3.7.x
-Tested on **Python 3.7.16** and confirmed that they are **not compatible**. Attempting to install dependencies on Python 3.7.x will result in a `subprocess-exited-with-error` during the `pip` installation of backend dependencies.
+Tested on **Python 3.7.16** and was confirmed that they are **not compatible**. Attempting to install dependencies on Python 3.7.x will result in a `subprocess-exited-with-error` during the `pip` installation of backend dependencies.
 
 **Error Example:**
 ```text

--- a/docs/DATA_PREPARATION.md
+++ b/docs/DATA_PREPARATION.md
@@ -1,6 +1,6 @@
 # Data Preparation
 
-This doc explains the preprocessing decisions in `scripts/prepare_data.py`.
+This documentation explains the preprocessing decisions in `scripts/prepare_data.py`.
 
 ---
 

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -11,7 +11,7 @@ Anti-spoofing is texture-sensitive, so input quality directly affects output rel
 
 The model was trained on a specific preprocessing pipeline, so it expects inputs that match that pipeline.
 
-* **The 1.5x padding:** The preprocessing uses 1.5x padding (`--bbox_expansion_factor 1.5`) when cropping faces. Tight crops (just eyes/forehead) remove the context needed to tell a real head apart from a flat screen or paper. The padding provides the model enough "head space" to see the 3D structure.
+* **The 1.5x padding:** The preprocessing uses 1.5x padding (`--bbox_expansion_factor 1.5`) when cropping faces. Tight crops (Just eyes/Forehead) remove the context needed to tell a real head apart from a flat screen or paper. The padding provides the model enough "head space" to see the 3D structure.
 * **Resolution:** Input gets resized to 128×128, but the source face should be at least 64×64. If you upscale a tiny, blurry face, you'll lose the spoofing artifacts (like screen pixels) that the model looks for.
 
 ## 3. Pose & Occlusion
@@ -28,8 +28,8 @@ The model was trained on a specific preprocessing pipeline, so it expects inputs
 
 The default threshold is balanced for general use (FPR < 2%). Security is a trade-off:
 
-* **High-security:** If you can't afford any spoofs getting through, bump the threshold (e.g., 0.5 → 0.8). This will also increase false rejects for real users.
-* **High-convenience:** If you want a smoother experience and can tolerate minor risks, lower thresholds work fine.
+* **High-security:** If you can't afford any spoofs getting through, you can bump the threshold (e.g., 0.5 → 0.8). This will also increase false rejects for real users.
+* **High-convenience:** If you want a smoother experience and can tolerate minor risks, lower thresholds should work fine.
 
 ## Implementation Example
 


### PR DESCRIPTION
This just fix some minor typos on the documentation
Signed-off by: <akosijoeyaibertcollado@gmail.com>